### PR TITLE
Auto translate

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -58,35 +58,42 @@ function translateComments(mutationsList, observer) {
     if (mutation.type == "childList") {
       mutation.addedNodes.forEach((node) => {
         if (node.nodeName.toLowerCase() == "ytd-comment-renderer") {
-          let bodyElement = node.querySelectorAll(
-            "#body #main #comment-content #expander #content #content-text"
-          );
+          let commentsList = node.querySelectorAll("#content-text");
 
-          if (bodyElement) {
-            bodyElement.forEach((element) => {
-              console.log(element.textContent);
-              console.log(element.className);
-              const spellcheckValue = element.getAttribute("spellcheck");
-              if (
-                element.textContent.trim() != "" &&
-                spellcheckValue != "false" &&
-                element.textContent != " " &&
-                !element.textContent.match(regexEmoji)
-              ) {
-                callTranslateAPI(element)
-                  .then((response) => {
-                    if (response && response.originalLanguage != "en") {
-                      element.textContent =
-                        response.translatedText +
-                        " (translated from " +
-                        response.originalLanguage +
-                        ")";
-                    }
-                  })
-                  .catch((error) => {
-                    console.log(error);
-                  });
-              }
+          if (commentsList) {
+            commentsList.forEach((comment) => {
+              let elementList = comment.childNodes;
+
+              elementList.forEach((element) => {
+                if (element) {
+                  console.log(element.textContent);
+                  console.log(element.className);
+
+                  if (
+                    element.textContent.trim() != "" &&
+                    element.textContent != " " &&
+                    !element.textContent.match(regexEmoji) &&
+                    element.className !=
+                      "yt-simple-endpoint style-scope yt-formatted-string"
+                  ) {
+                    callTranslateAPI(element)
+                      .then((response) => {
+                        if (response && response.originalLanguage != "en") {
+                          element.textContent =
+                            response.translatedText +
+                            " (translated from " +
+                            response.originalLanguage +
+                            ")";
+                        }
+                      })
+                      .catch((error) => {
+                        console.log(error);
+                      });
+                  } else {
+                    element.textContent = element.textContent + " ";
+                  }
+                }
+              });
             });
           }
         }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,6 +1,6 @@
 /** Google Translate API */
 
-const key = "AIzaSyAffFHGY4Q4URrju5AXeLlu7XQJrijLF8M"; // Insert Key Here
+const key = ""; // Insert Key Here
 const translateURL = `https://translation.googleapis.com/language/translate/v2?key=${key}`;
 const detectURL = `https://translation.googleapis.com/language/translate/v2/detect?key=${key}`;
 const commentWrapper = document.body;

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,6 +1,6 @@
 /** Google Translate API */
 
-const key = "AIzaSyAffFHGY4Q4URrju5AXeLlu7XQJrijLF8M"; // Insert Key Here
+const key = ""; // Insert Key Here
 const translateURL = `https://translation.googleapis.com/language/translate/v2?key=${key}`;
 const commentWrapper = document.body;
 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -7,6 +7,12 @@ const regexEmoji =
   /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu;
 const commentWrapper = document.body;
 
+const config = {
+  childList: true,
+  subtree: true,
+};
+let observer;
+
 /**
  * Calls the Google Translate API
  * @param  {object} text  text element object.
@@ -53,51 +59,59 @@ function callTranslateAPI(text) {
  * @param  {object} mutationsList  text element object.
  * @param  {object} observer  observer properties.
  */
-function translateComments(mutationsList, observer) {
+async function translateComments(mutationsList, observer) {
   for (const mutation of mutationsList) {
     if (mutation.type == "childList") {
-      mutation.addedNodes.forEach((node) => {
+      for (const node of mutation.addedNodes) {
         if (node.nodeName.toLowerCase() == "ytd-comment-renderer") {
           let commentsList = node.querySelectorAll("#content-text");
 
-          if (commentsList) {
-            commentsList.forEach((comment) => {
-              let elementList = comment.childNodes;
+          for (const comment of commentsList) {
+            let elementList = comment.childNodes;
+            let translationOccurred = false;
+            let originalLanguage = "";
 
-              elementList.forEach((element) => {
-                if (element) {
-                  console.log(element.textContent);
-                  console.log(element.className);
+            let translationPromises = [];
 
-                  if (
-                    element.textContent.trim() != "" &&
-                    element.textContent != " " &&
-                    !element.textContent.match(regexEmoji) &&
-                    element.className !=
-                      "yt-simple-endpoint style-scope yt-formatted-string"
-                  ) {
-                    callTranslateAPI(element)
-                      .then((response) => {
-                        if (response && response.originalLanguage != "en") {
-                          element.textContent =
-                            response.translatedText +
-                            " (translated from " +
-                            response.originalLanguage +
-                            ")";
-                        }
-                      })
-                      .catch((error) => {
-                        console.log(error);
-                      });
-                  } else {
-                    element.textContent = element.textContent + " ";
-                  }
+            elementList.forEach((element, index) => {
+              if (element) {
+                if (
+                  element.textContent.trim() != "" &&
+                  !element.textContent.match(regexEmoji) &&
+                  element.className !=
+                    "yt-simple-endpoint style-scope yt-formatted-string"
+                ) {
+                  const translatePromise = callTranslateAPI(element)
+                    .then((response) => {
+                      if (response && response.originalLanguage != "en") {
+                        element.textContent = response.translatedText;
+                        translationOccurred = true;
+                        originalLanguage = response.originalLanguage;
+                      }
+                    })
+                    .catch((error) => {
+                      console.log(error);
+                    });
+                  translationPromises.push(translatePromise);
+                } else if (
+                  element.className ==
+                  "yt-simple-endpoint style-scope yt-formatted-string"
+                ) {
+                  element.textContent = element.textContent + "";
                 }
-              });
+              }
             });
+            await Promise.all(translationPromises);
+            let newSpan = document.createElement("span");
+            newSpan.setAttribute("dir", "auto");
+            newSpan.className = "style-scope yt-formatted-string";
+            newSpan.style.display = "block";
+            newSpan.textContent =
+              "\n (translated from " + originalLanguage + ")";
+            comment.parentNode.insertBefore(newSpan, comment.nextSibling);
           }
         }
-      });
+      }
     }
   }
 }
@@ -128,8 +142,6 @@ function translateComments(mutationsList, observer) {
 /**
  * Observer to translate new comments on load
  */
-const observer = new MutationObserver(translateComments);
-observer.observe(document.body, {
-  childList: true,
-  subtree: true,
-});
+
+observer = new MutationObserver(translateComments);
+observer.observe(document.body, config);

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -147,6 +147,6 @@ commentWrapper.addEventListener("click", (event) => {
     });
 });
 
-// Observer Setup
+// Observer to translate new comments on load
 observer = new MutationObserver(translateComments);
 observer.observe(document.body, config);

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,8 +1,7 @@
 /** Google Translate API */
 
-const key = ""; // Insert Key Here
+const key = "AIzaSyAffFHGY4Q4URrju5AXeLlu7XQJrijLF8M"; // Insert Key Here
 const translateURL = `https://translation.googleapis.com/language/translate/v2?key=${key}`;
-const detectURL = `https://translation.googleapis.com/language/translate/v2/detect?key=${key}`;
 const commentWrapper = document.body;
 
 /**
@@ -107,15 +106,17 @@ async function translateComments(mutationsList, observer) {
             // Adding translation tag after entire comment has been translated
             await Promise.all(translationPromises);
 
-            let newSpan = document.createElement("span");
-            newSpan.setAttribute("dir", "auto");
-            newSpan.className = "style-scope yt-formatted-string";
-            newSpan.style.display = "block";
-            newSpan.textContent =
-              "\n (translated from " + originalLanguage + ")";
+            if (translationOccurred) {
+              let newSpan = document.createElement("span");
+              newSpan.setAttribute("dir", "auto");
+              newSpan.className = "style-scope yt-formatted-string";
+              newSpan.style.display = "block";
+              newSpan.textContent =
+                "\n (translated from " + originalLanguage + ")";
 
-            // Add new tag directly into the DOM
-            comment.parentNode.insertBefore(newSpan, comment.nextSibling);
+              // Add new tag directly into the DOM
+              comment.parentNode.insertBefore(newSpan, comment.nextSibling);
+            }
           }
         }
       }
@@ -146,8 +147,6 @@ commentWrapper.addEventListener("click", (event) => {
     });
 });
 
-/**
- * Observer setup
- */
+// Observer Setup
 observer = new MutationObserver(translateComments);
 observer.observe(document.body, config);

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -32,10 +32,13 @@ function callTranslateAPI(text) {
       })
         .then((response) => response.json())
         .then((data) => {
-          // console.log(
-          //   data.data.translations[0].translatedText.replace(/&#39;/g, "'")
-          // );
-          // console.log(data.data.translations[0].detectedSourceLanguage);
+          if (data.data.translations[0].detectedSourceLanguage != "en") {
+            console.log(
+              data.data.translations[0].translatedText.replace(/&#39;/g, "'")
+            );
+            console.log(data.data.translations[0].detectedSourceLanguage);
+          }
+
           resolve({
             translatedText: data.data.translations[0].translatedText.replace(
               /&#39;/g,

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -39,7 +39,6 @@ function callTranslateAPI(text) {
             );
             console.log(data.data.translations[0].detectedSourceLanguage);
           }
-
           resolve({
             translatedText: data.data.translations[0].translatedText.replace(
               /&#39;/g,
@@ -104,13 +103,18 @@ async function translateComments(mutationsList, observer) {
                 }
               }
             });
+
+            // Adding translation tag after entire comment has been translated
             await Promise.all(translationPromises);
+
             let newSpan = document.createElement("span");
             newSpan.setAttribute("dir", "auto");
             newSpan.className = "style-scope yt-formatted-string";
             newSpan.style.display = "block";
             newSpan.textContent =
               "\n (translated from " + originalLanguage + ")";
+
+            // Add new tag directly into the DOM
             comment.parentNode.insertBefore(newSpan, comment.nextSibling);
           }
         }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -3,10 +3,11 @@
 const key = "AIzaSyAffFHGY4Q4URrju5AXeLlu7XQJrijLF8M"; // Insert Key Here
 const translateURL = `https://translation.googleapis.com/language/translate/v2?key=${key}`;
 const detectURL = `https://translation.googleapis.com/language/translate/v2/detect?key=${key}`;
-const regexEmoji =
-  /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/gu;
 const commentWrapper = document.body;
 
+/**
+ * Observer to translate new comments on load
+ */
 const config = {
   childList: true,
   subtree: true,
@@ -80,7 +81,6 @@ async function translateComments(mutationsList, observer) {
               if (element) {
                 if (
                   element.textContent.trim() != "" &&
-                  !element.textContent.match(regexEmoji) &&
                   element.className !=
                     "yt-simple-endpoint style-scope yt-formatted-string"
                 ) {
@@ -122,29 +122,28 @@ async function translateComments(mutationsList, observer) {
 /**
  * Translates comments on click
  */
-// commentWrapper.addEventListener("click", (event) => {
-//   const comment = event.target.closest("yt-formatted-string");
+commentWrapper.addEventListener("click", (event) => {
+  const comment = event.target.closest("yt-formatted-string");
 
-//   callTranslateAPI(comment)
-//     .then((response) => {
-//       if (response) {
-//         comment.textContent =
-//           response.translatedText +
-//           " (translated from " +
-//           response.originalLanguage +
-//           ")";
-//         console.log("Translated text:", response.translatedText);
-//         console.log("Original language:", response.originalLanguage);
-//       }
-//     })
-//     .catch((error) => {
-//       console.log(error);
-//     });
-// });
+  callTranslateAPI(comment)
+    .then((response) => {
+      if (response) {
+        comment.textContent =
+          response.translatedText +
+          " (translated from " +
+          response.originalLanguage +
+          ")";
+        console.log("Translated text:", response.translatedText);
+        console.log("Original language:", response.originalLanguage);
+      }
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+});
 
 /**
- * Observer to translate new comments on load
+ * Observer setup
  */
-
 observer = new MutationObserver(translateComments);
 observer.observe(document.body, config);

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -32,7 +32,7 @@ function callTranslateAPI(text) {
       })
         .then((response) => response.json())
         .then((data) => {
-          if (data.data.translations[0].detectedSourceLanguage != "en") {
+          if (data.data.translations[0].detectedSourceLanguage !== "en") {
             console.log(
               data.data.translations[0].translatedText.replace(/&#39;/g, "'")
             );
@@ -63,9 +63,9 @@ function callTranslateAPI(text) {
  */
 async function translateComments(mutationsList, observer) {
   for (const mutation of mutationsList) {
-    if (mutation.type == "childList") {
+    if (mutation.type === "childList") {
       for (const node of mutation.addedNodes) {
-        if (node.nodeName.toLowerCase() == "ytd-comment-renderer") {
+        if (node.nodeName.toLowerCase() === "ytd-comment-renderer") {
           let commentsList = node.querySelectorAll("#content-text");
 
           for (const comment of commentsList) {
@@ -78,13 +78,13 @@ async function translateComments(mutationsList, observer) {
             elementList.forEach((element, index) => {
               if (element) {
                 if (
-                  element.textContent.trim() != "" &&
-                  element.className !=
+                  element.textContent.trim() !== "" &&
+                  element.className !==
                     "yt-simple-endpoint style-scope yt-formatted-string"
                 ) {
                   const translatePromise = callTranslateAPI(element)
                     .then((response) => {
-                      if (response && response.originalLanguage != "en") {
+                      if (response && response.originalLanguage !== "en") {
                         element.textContent = response.translatedText;
                         translationOccurred = true;
                         originalLanguage = response.originalLanguage;
@@ -95,7 +95,7 @@ async function translateComments(mutationsList, observer) {
                     });
                   translationPromises.push(translatePromise);
                 } else if (
-                  element.className ==
+                  element.className ===
                   "yt-simple-endpoint style-scope yt-formatted-string"
                 ) {
                   element.textContent = element.textContent + "";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improved `translateComments` with various fixes

## Description
Optimized `translateComments` to better target comment components and eliminate language detect API calls since translating costs the same (and can detect languages!)

Added one translation tag per comment at the bottom of the comment (see issue #4)

Also cleaned up code a little bit for readability (too many brackets lol), and simplified where needed.

![](https://github.com/wastadtlander/Youtube-Comment-Translator/assets/35006641/7466d6d8-2298-418b-b2d1-1584d8d93db4)
