### PR TITLE
Standardized translation tag

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,15 @@
 {
-    "manifest_version": 3,
-    "name": "Comment Translator",
-    "version": "1.0",
-    "description": "Translates Youtube comments.",
-    "action": {
-        "default_title": "Comment Translator",
-        "default_popup": "html/popup.html"
-    },
-    "content_scripts": [
-        {
-            "js": ["js/content.js"],
-            "matches": ["https://www.youtube.com/watch?v=*"]
-        }
-    ]
+  "manifest_version": 3,
+  "name": "Comment Translator",
+  "version": "1.0",
+  "description": "Translates Youtube comments.",
+  "action": {
+    "default_title": "Comment Translator",
+    "default_popup": "html/popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.youtube.com/watch?v=*"]
+    }
+  ]
 }

--- a/src/chromeServices/content.ts
+++ b/src/chromeServices/content.ts
@@ -15,6 +15,7 @@ let observer;
 /**
  * Calls the Google Translate API
  * @param  {HTMLElement} text  text element object.
+ * @return {Promise<TranslateAPIResponse>} list of API responses.
  */
 function callTranslateAPI(
   text: HTMLElement | Text
@@ -58,6 +59,12 @@ function callTranslateAPI(
   });
 }
 
+/**
+ * Automatically translates comments on load
+ *
+ * @param  {HTMLElement} comment  comment to translate.
+ * @return {Promise<void>}        empty promise.
+ */
 async function translateComment(comment: HTMLElement): Promise<void> {
   let translationOccurred = false;
   let originalLanguage = "";
@@ -100,6 +107,7 @@ async function translateComment(comment: HTMLElement): Promise<void> {
       }
     }
   }
+
   // Adding translation tag after entire comment has been translated
   await Promise.all(translationPromises);
 
@@ -120,6 +128,7 @@ async function translateComment(comment: HTMLElement): Promise<void> {
  *
  * @param  {object} mutationsList  text element object.
  * @param  {object} observer  observer properties.
+ * @return {void}
  */
 async function translateAllComments(
   mutationsList: MutationRecord[],

--- a/src/chromeServices/content.ts
+++ b/src/chromeServices/content.ts
@@ -35,9 +35,13 @@ function callTranslateAPI(
         .then((data) => {
           if (data.data.translations[0].detectedSourceLanguage !== "en") {
             console.log(
-              data.data.translations[0].translatedText.replace(/&#39;/g, "'")
+              "Translation: " +
+                data.data.translations[0].translatedText.replace(/&#39;/g, "'")
             );
-            console.log(data.data.translations[0].detectedSourceLanguage);
+            console.log(
+              "Original Language: " +
+                data.data.translations[0].detectedSourceLanguage
+            );
           }
           resolve({
             translatedText: data.data.translations[0].translatedText.replace(
@@ -54,77 +58,81 @@ function callTranslateAPI(
   });
 }
 
+async function translateComment(comment: HTMLElement): Promise<void> {
+  let translationOccurred = false;
+  let originalLanguage = "";
+
+  let translationPromises: Promise<void>[] = [];
+
+  for (const element of comment.childNodes) {
+    if (element instanceof HTMLElement || element instanceof Text) {
+      // Extract textContent and check if it's not null and not empty
+      const textContent = element.textContent || "";
+
+      if (
+        textContent.trim() !== "" &&
+        !(
+          element instanceof HTMLElement &&
+          element.className ===
+            "yt-simple-endpoint style-scope yt-formatted-string"
+        )
+      ) {
+        const translatePromise = callTranslateAPI(element)
+          .then((response: TranslateAPIResponse) => {
+            if (response && response.originalLanguage !== "en") {
+              element.textContent = response.translatedText + " ";
+              translationOccurred = true;
+              originalLanguage = response.originalLanguage;
+            }
+          })
+          .catch((error: any) => {
+            console.log(error);
+          });
+        translationPromises.push(translatePromise);
+      }
+      // Adds a extra space after links
+      else if (
+        element instanceof HTMLElement &&
+        element.className ===
+          "yt-simple-endpoint style-scope yt-formatted-string"
+      ) {
+        element.textContent += " ";
+      }
+    }
+  }
+  // Adding translation tag after entire comment has been translated
+  await Promise.all(translationPromises);
+
+  if (translationOccurred && comment.parentNode) {
+    let newSpan = document.createElement("span");
+    newSpan.setAttribute("dir", "auto");
+    newSpan.className = "style-scope yt-formatted-string";
+    newSpan.style.display = "block";
+    newSpan.textContent = "\n (translated from " + originalLanguage + ")";
+
+    // Add new tag directly into the DOM
+    comment.parentNode.insertBefore(newSpan, comment.nextSibling);
+  }
+}
+
 /**
  * Automatically translates comments on load
  *
  * @param  {object} mutationsList  text element object.
  * @param  {object} observer  observer properties.
  */
-async function translateComments(
+async function translateAllComments(
   mutationsList: MutationRecord[],
   observer: MutationObserver
 ) {
-  for (const mutation of mutationsList) {
-    if (mutation.type === "childList") {
-      for (const node of mutation.addedNodes) {
-        // Type cast node to HTMLElement to access querySelectorAll and other properties
-        if (
-          node.nodeName.toLowerCase() === "ytd-comment-renderer" &&
-          node instanceof Element
-        ) {
-          let commentsList = node.querySelectorAll("#content-text");
-
-          for (const comment of commentsList) {
-            let elementList = comment.childNodes;
-            let translationOccurred = false;
-            let originalLanguage = "";
-
-            let translationPromises: Promise<void>[] = [];
-
-            for (const element of elementList) {
-              if (element instanceof HTMLElement || element instanceof Text) {
-                // Extract textContent and check if it's not null and not empty
-                const textContent = element.textContent || "";
-
-                if (
-                  textContent.trim() !== "" &&
-                  !(
-                    element instanceof HTMLElement &&
-                    element.className ===
-                      "yt-simple-endpoint style-scope yt-formatted-string"
-                  )
-                ) {
-                  const translatePromise = callTranslateAPI(element)
-                    .then((response: TranslateAPIResponse) => {
-                      if (response && response.originalLanguage !== "en") {
-                        element.textContent = response.translatedText;
-                        translationOccurred = true;
-                        originalLanguage = response.originalLanguage;
-                      }
-                    })
-                    .catch((error: any) => {
-                      console.log(error);
-                    });
-                  translationPromises.push(translatePromise);
-                }
-              }
-            }
-
-            // Adding translation tag after entire comment has been translated
-            await Promise.all(translationPromises);
-
-            if (translationOccurred && comment.parentNode) {
-              let newSpan = document.createElement("span");
-              newSpan.setAttribute("dir", "auto");
-              newSpan.className = "style-scope yt-formatted-string";
-              newSpan.style.display = "block";
-              newSpan.textContent =
-                "\n (translated from " + originalLanguage + ")";
-
-              // Add new tag directly into the DOM
-              comment.parentNode.insertBefore(newSpan, comment.nextSibling);
-            }
-          }
+  for (const mutation of mutationsList.filter((m) => m.type === "childList")) {
+    for (const node of mutation.addedNodes) {
+      if (
+        node.nodeName.toLowerCase() === "ytd-comment-renderer" &&
+        node instanceof Element
+      ) {
+        for (const comment of node.querySelectorAll("#content-text")) {
+          translateComment(comment as HTMLElement);
         }
       }
     }
@@ -137,27 +145,12 @@ async function translateComments(
 commentWrapper.addEventListener("click", (event) => {
   if (event.target && event.target instanceof Element) {
     const comment = event.target.closest("yt-formatted-string");
-
-    if (comment && comment instanceof HTMLElement) {
-      callTranslateAPI(comment)
-        .then((response) => {
-          if (response) {
-            comment.textContent =
-              response.translatedText +
-              " (translated from " +
-              response.originalLanguage +
-              ")";
-            console.log("Translated text:", response.translatedText);
-            console.log("Original language:", response.originalLanguage);
-          }
-        })
-        .catch((error) => {
-          console.log(error);
-        });
+    if (comment) {
+      translateComment(comment as HTMLElement);
     }
   }
 });
 
 // Observer to translate new comments on load
-observer = new MutationObserver(translateComments);
+observer = new MutationObserver(translateAllComments);
 observer.observe(document.body, config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Standardized translation tag

## Description
Previously, clicked comment's translation tag did not match the auto-translate tag, as it simply edited the `textContent` vs adding a new span element. Changes standardized the two tags, and standardized the translation through `translateComment` function.

## Other
Also condensed the code a lil bit